### PR TITLE
Added /playlist command, Spotify track search, and error handling for YT search

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const { joinVoiceChannel } = require('@discordjs/voice');
 
 const { Youtube, searchYoutube } = require('../models/youtube');
-const Spotify = './models/spotify';
+const { getTrackName } = require('../models/spotify');
 
 
 module.exports = {
@@ -47,7 +47,13 @@ module.exports = {
             }
 
             song = new Youtube(videoId);
-        } else {
+        } 
+        // Check if the query is a Spotify track URL
+        else if (query.includes('open.spotify.com/track')) {
+            // Find the song by title on youtube
+            song = new Youtube(await searchYoutube(await getTrackName(query.substring(query.lastIndexOf('/') + 1).split('?')[0])));
+        }
+        else {
             // Search for YouTube videos by keyword
             // TODO something smart if there's no result
             song = new Youtube(await searchYoutube(query));

--- a/commands/play.js
+++ b/commands/play.js
@@ -3,6 +3,7 @@ const { joinVoiceChannel } = require('@discordjs/voice');
 
 const { Youtube, searchYoutube } = require('../models/youtube');
 const { getTrackName } = require('../models/spotify');
+const Song = require('../models/song');
 
 
 module.exports = {
@@ -55,16 +56,23 @@ module.exports = {
         }
         else {
             // Search for YouTube videos by keyword
-            // TODO something smart if there's no result
-            song = new Youtube(await searchYoutube(query));
+            const ytId = await searchYoutube(query);
+            if (ytId === null) {
+                song = {};
+                await interaction.editReply('An error occurred, you\'ve likely exceeded your YouTube search quota. Please try again later.');
+            }
+            else
+                song = new Youtube(ytId);
         }
 
-        song.connection = connection;
-        try {
-            global.queue.push(song, interaction);
-        }
-        catch (e) {
-            console.log(e);
+        if(song instanceof Song) {
+            song.connection = connection;
+            try {
+                global.queue.push(song, interaction);
+            }
+            catch (e) {
+                console.log(e);
+            }
         }
     }
 };

--- a/commands/playlist.js
+++ b/commands/playlist.js
@@ -1,0 +1,42 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+const { getPlaylist } = require('../models/spotify');
+const { Youtube } = require('../models/youtube');
+
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('playlist')
+        .setDescription('Add a Spotify playlist to the queue.'),
+
+        async execute(interaction) {
+            // Get the user's voice channel
+            const voiceChannel = interaction.member.voice.channel;
+        
+            // Check if the user is in a voice channel
+            if (!voiceChannel) {
+                interaction.reply('You must be in a voice channel to add a playlist!');
+                return;
+            }
+        
+            await interaction.deferReply();
+            const query = interaction.options.getString('query') ?? 'No URL or search provided!';
+            let song;
+
+            // Check if the query is a Spotify playlist URL
+            if (query.includes('open.spotify.com/playlist')) {
+                // Find the song by title on youtube
+                const playlistId = query.substring(query.lastIndexOf('/') + 1).split('?')[0];
+                const playlists = await getPlaylist();
+
+                for (p of playlists) {
+                    song = new Youtube(p.name);
+                    song.connection = connection;
+                    global.queue.push(song, interaction);
+                }
+            }
+            else {
+                interaction.editReply('Please enter a valid Spotify playlist URL.');
+            }
+        },
+};

--- a/commands/playlist.js
+++ b/commands/playlist.js
@@ -1,13 +1,18 @@
 const { SlashCommandBuilder } = require('discord.js');
+const { joinVoiceChannel } = require('@discordjs/voice');
 
 const { getPlaylist } = require('../models/spotify');
-const { Youtube } = require('../models/youtube');
+const { Youtube, searchYoutube } = require('../models/youtube');
 
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('playlist')
-        .setDescription('Add a Spotify playlist to the queue.'),
+        .setDescription('Add a Spotify playlist to the queue.')
+        .addStringOption(option =>
+            option.setName('query')
+                .setDescription('The YouTube or Spotify URL or search query.')
+                .setRequired(true)),
 
         async execute(interaction) {
             // Get the user's voice channel
@@ -18,7 +23,14 @@ module.exports = {
                 interaction.reply('You must be in a voice channel to add a playlist!');
                 return;
             }
-        
+
+            // Join the user's voice channel
+            const connection = joinVoiceChannel({
+                channelId: voiceChannel.id,
+                guildId: voiceChannel.guild.id,
+                adapterCreator: voiceChannel.guild.voiceAdapterCreator,
+            });
+
             await interaction.deferReply();
             const query = interaction.options.getString('query') ?? 'No URL or search provided!';
             let song;
@@ -27,12 +39,21 @@ module.exports = {
             if (query.includes('open.spotify.com/playlist')) {
                 // Find the song by title on youtube
                 const playlistId = query.substring(query.lastIndexOf('/') + 1).split('?')[0];
-                const playlists = await getPlaylist();
+                const playlists = await getPlaylist(playlistId);
 
-                for (p of playlists) {
-                    song = new Youtube(p.name);
-                    song.connection = connection;
-                    global.queue.push(song, interaction);
+                // We only allow 10 to conserve YouTube search quota
+                for (let i = 0; i < 10; i++) {
+                    const ytId = await searchYoutube(playlists[i].track.name);
+
+                    if (ytId === null)
+                    {
+                        await interaction.editReply('An error occurred, you\'ve likely exceeded your YouTube search quota. Please try again later.');
+                    }
+                    else {
+                        song = new Youtube(ytId);
+                        song.connection = connection;
+                        global.queue.push(song, interaction);
+                    }
                 }
             }
             else {

--- a/models/spotify.js
+++ b/models/spotify.js
@@ -2,5 +2,26 @@ const SpotifyWebApi = require('spotify-web-api-node');
 const dotenv = require('dotenv').config({ path: `${__dirname}/../.env` })
 const spotifyApi = new SpotifyWebApi({
     clientId: process.env.SPOTIFY_CLIENT_ID,
-    clientSecret: process.env.SPOTIFY_CLIENT_SECRET
+    clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+    redirectUri: 'http://www.example.com/callback'
 });
+
+const getToken = async () => {
+    return (await spotifyApi.clientCredentialsGrant()).body['access_token'];
+};
+
+const getTrackName = async (id) => {
+    spotifyApi.setAccessToken(await getToken());
+    const track = await spotifyApi.getTrack(id)
+    return `${track.body.name} by ${track.body.artists[0].name}`;
+};
+
+const getPlaylist = async (id) => {
+    spotifyApi.setAccessToken(await getToken());
+    return (await spotifyApi.getPlaylist(id)).items;
+}
+
+module.exports = {
+    getTrackName,
+    getPlaylist
+};

--- a/models/spotify.js
+++ b/models/spotify.js
@@ -18,7 +18,7 @@ const getTrackName = async (id) => {
 
 const getPlaylist = async (id) => {
     spotifyApi.setAccessToken(await getToken());
-    return (await spotifyApi.getPlaylist(id)).items;
+    return (await spotifyApi.getPlaylist(id)).body.tracks.items;
 }
 
 module.exports = {

--- a/models/youtube.js
+++ b/models/youtube.js
@@ -11,14 +11,20 @@ const Song = require('./song');
 
 const searchYoutube = async (query) => {
     // Search for YouTube videos
-    const response = await youtube.search.list({
-        part: 'id',
-        type: 'video',
-        q: query,
-    });
+    try {
+        const response = await youtube.search.list({
+            part: 'id',
+            type: 'video',
+            q: query,
+        });
 
-    // Get the first result
-    return response.data.items[0].id.videoId;
+        // Get the first result
+        return response.data.items[0].id.videoId;
+    }
+    catch (e) {
+        console.log(`Failed to search YouTube: ${e}`);
+        return null;
+    }
 };
 
 class Youtube extends Song {


### PR DESCRIPTION
Added support for spotify track links in the /play query; just finds the equivalent link on youtube for now. Also added a /playlist command that takes a spotify playlist link and adds the equivalent youtube links to the queue, capped at first 10 songs in the playlist due to YT search quotas (100/day max).